### PR TITLE
解决生成的小程序链接无法正确获取 query 参数问题

### DIFF
--- a/lcmall-api/src/main/java/com/lcsays/lcmall/api/controller/weixin/WxMaMarketingController.java
+++ b/lcmall-api/src/main/java/com/lcsays/lcmall/api/controller/weixin/WxMaMarketingController.java
@@ -245,7 +245,7 @@ public class WxMaMarketingController {
         try {
             GenerateUrlLinkRequest request = GenerateUrlLinkRequest.builder().build();
             request.setPath("/pages/stock/index");
-            request.setQuery("?activityId=" + activityId + "&templateType=" + templateType);
+            request.setQuery("activityId=" + activityId + "&templateType=" + templateType);
             request.setIsExpire(false);
             String result = wxMaService.switchoverTo(appId).getLinkService().generateUrlLink(request);
             result = result.replaceAll("\"", "");


### PR DESCRIPTION
解决 #1 中的缺陷。
删除生成小程序分享链接时 query 参数前面的?，否则第一个参数名将是以问号开头的，导致无法正确获取。